### PR TITLE
MATLAB solver stats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MATLABDiffEq"
 uuid = "e2752cbe-bcf4-5895-8727-84ebc14a76bd"
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/MATLABDiffEq.jl
+++ b/src/MATLABDiffEq.jl
@@ -94,6 +94,7 @@ function buildDEStats(solverstats::Dict)
     destats.naccept = if (haskey(solverstats, "nsteps")) solverstats["nsteps"] else 0 end
     destats.nsolve = if (haskey(solverstats, "nsolves")) solverstats["nsolves"] else 0 end
     destats.njacs = if (haskey(solverstats, "npds")) solverstats["npds"] else 0 end
+    destats.nw = if (haskey(solverstats, "ndecomps")) solverstats["ndecomps"] else 0 end
     destats
 end
 

--- a/src/MATLABDiffEq.jl
+++ b/src/MATLABDiffEq.jl
@@ -81,6 +81,11 @@ function DiffEqBase.__solve(
         timeseries = timeseries_tmp
     end
 
+    destats = DiffEqBase.DEStats(0)
+
+    # destats.naccept = solstats["nsteps"]
+    # #destats.nsolve = solstats[""]
+
     DiffEqBase.build_solution(prob,alg,ts,timeseries,
                  timeseries_errors = timeseries_errors,destats=solstats)
 end

--- a/src/MATLABDiffEq.jl
+++ b/src/MATLABDiffEq.jl
@@ -62,10 +62,9 @@ function DiffEqBase.__solve(
 
     eval_string("options = odeset('RelTol',reltol,'AbsTol',abstol);")
     algstr = string(typeof(alg).name.name)
-    @show algstr
     eval_string("mxsol = $(algstr)(diffeqf,tspan,u0,options);")
     eval_string("mxsolstats = struct(mxsol.stats);")
-    solstats= get_variable(:mxsolstats)
+    solstats = get_variable(:mxsolstats)
     eval_string("t = mxsol.x;")
     ts = jvector(get_mvariable(:t))
     eval_string("u = mxsol.y';")
@@ -81,13 +80,21 @@ function DiffEqBase.__solve(
         timeseries = timeseries_tmp
     end
 
-    destats = DiffEqBase.DEStats(0)
-
-    # destats.naccept = solstats["nsteps"]
-    # #destats.nsolve = solstats[""]
+    destats = buildDEStats(solstats)
 
     DiffEqBase.build_solution(prob,alg,ts,timeseries,
-                 timeseries_errors = timeseries_errors,destats=solstats)
+                 timeseries_errors = timeseries_errors,destats = destats)
+end
+
+function buildDEStats(solverstats::Dict)
+
+    destats = DiffEqBase.DEStats(0)
+    destats.nf = if (haskey(solverstats, "nfevals")) solverstats["nfevals"] else 0 end
+    destats.nreject = if (haskey(solverstats, "nfailed")) solverstats["nfailed"] else 0 end
+    destats.naccept = if (haskey(solverstats, "nsteps")) solverstats["nsteps"] else 0 end
+    destats.nsolve = if (haskey(solverstats, "nsolves")) solverstats["nsolves"] else 0 end
+    destats.njacs = if (haskey(solverstats, "npds")) solverstats["npds"] else 0 end
+    destats
 end
 
 end # module

--- a/src/MATLABDiffEq.jl
+++ b/src/MATLABDiffEq.jl
@@ -62,9 +62,13 @@ function DiffEqBase.__solve(
 
     eval_string("options = odeset('RelTol',reltol,'AbsTol',abstol);")
     algstr = string(typeof(alg).name.name)
-    #algstr = replace(string(typeof(alg)),"MATLABDiffEq.","")
-    eval_string("[t,u] = $(algstr)(diffeqf,tspan,u0,options);")
+    @show algstr
+    eval_string("mxsol = $(algstr)(diffeqf,tspan,u0,options);")
+    eval_string("mxsolstats = struct(mxsol.stats);")
+    solstats= get_variable(:mxsolstats)
+    eval_string("t = mxsol.x;")
     ts = jvector(get_mvariable(:t))
+    eval_string("u = mxsol.y';")
     timeseries_tmp = jarray(get_mvariable(:u))
 
     # Reshape the result if needed
@@ -78,7 +82,7 @@ function DiffEqBase.__solve(
     end
 
     DiffEqBase.build_solution(prob,alg,ts,timeseries,
-                 timeseries_errors = timeseries_errors)
+                 timeseries_errors = timeseries_errors,destats=solstats)
 end
 
 end # module


### PR DESCRIPTION
As discussed in #18 , I have exported stats from MATLAB into a `Dict`. I have also changed the implementation to directly compute the `mxsol` struct sol we can integrate new options. I had used extra `eval_string` because of the incompatibility of `MATLAB.jl` to parse nested structs. Incremented the patch version too. Also should no. of LU decompositions parameter MATLAB should be linked to what in `DEStats`?