### PR TITLE
Bump compat for OrdinaryDiffEq v7 / SciMLBase v3 ecosystem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-DiffEqBase = "6.122"
+DiffEqBase = "6.122, 7"
 JET = "0.9, 0.10, 0.11"
 MATLAB = "0.8, 0.9"
 ModelingToolkit = "8, 9, 10, 11"


### PR DESCRIPTION
## Summary

- Widens `DiffEqBase` compat from `"6.122"` to `"6.122, 7"` to allow the v7 ecosystem (DiffEqBase v7, SciMLBase v3, RecursiveArrayTools v4).
- No source changes required: all APIs used by this package (`DiffEqBase.__solve`, `build_solution`, `AbstractODEAlgorithm`, `AbstractODEProblem`, `DiffEqBase.Stats`) remain available in v7 — `Stats` is aliased to `SciMLBase.DEStats` in DiffEqBase v7's `stats.jl`.
- Resolve confirmed: `Pkg.add("DiffEqBase@7")` picks DiffEqBase v7.0.0 + SciMLBase v3.6.0 without conflict.

## Test plan

- [ ] CI passes (note: MATLAB runtime tests are skipped in CI; JET static analysis and interface tests run without MATLAB)
- [ ] Verify `DiffEqBase = "6.122, 7"` resolves on both v6 and v7 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)