### PR TITLE
[UNVERIFIED-needs-MATLAB] test: skip MATLAB runtime tests when no MATLAB is installed

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using DiffEqBase, MATLABDiffEq, ParameterizedFunctions, Test
+using MATLAB
 
 # Interface tests - these test type validation without needing MATLAB runtime
 include("interface_tests.jl")
@@ -6,39 +7,59 @@ include("interface_tests.jl")
 # JET static analysis tests - these also run without MATLAB
 include("jet_tests.jl")
 
-# The following tests require MATLAB runtime to be available
-# They test the actual ODE solving functionality
+# The following tests require a MATLAB installation to be available at build
+# time. MATLAB.jl exposes `libmx_size`, which is 0 when no MATLAB was found
+# (e.g. CI without a MATLAB license). In that case the function pointers into
+# the MATLAB engine are never bound, so any solve would throw an UndefRefError
+# when it tries to open an engine session. Gate the runtime tests on a real
+# MATLAB being present rather than letting the suite error out.
+const HAS_MATLAB = MATLAB.libmx_size > 0
 
-f = @ode_def_bare LotkaVolterra begin
-    dx = a * x - b * x * y
-    dy = -c * y + d * x * y
-end a b c d
-p = [1.5, 1, 3, 1]
-tspan = (0.0, 10.0)
-u0 = [1.0, 1.0]
-prob = ODEProblem(f, u0, tspan, p)
-sol = solve(prob, MATLABDiffEq.ode45())
+if HAS_MATLAB
+    @testset "MATLAB runtime solving" begin
+        f = @ode_def_bare LotkaVolterra begin
+            dx = a * x - b * x * y
+            dy = -c * y + d * x * y
+        end a b c d
+        p = [1.5, 1, 3, 1]
+        tspan = (0.0, 10.0)
+        u0 = [1.0, 1.0]
+        prob = ODEProblem(f, u0, tspan, p)
+        sol = solve(prob, MATLABDiffEq.ode45())
+        @test length(sol.t) > 1
+        @test length(sol.u) == length(sol.t)
+        @test sol.t[1] == tspan[1]
+        @test sol.t[end] == tspan[2]
 
-function lorenz(du, u, p, t)
-    du[1] = 10.0(u[2] - u[1])
-    du[2] = u[1] * (28.0 - u[3]) - u[2]
-    return du[3] = u[1] * u[2] - (8 / 3) * u[3]
-end
-u0 = [1.0; 0.0; 0.0]
-tspan = (0.0, 100.0)
-prob = ODEProblem(lorenz, u0, tspan)
-sol = solve(prob, MATLABDiffEq.ode45())
+        function lorenz(du, u, p, t)
+            du[1] = 10.0(u[2] - u[1])
+            du[2] = u[1] * (28.0 - u[3]) - u[2]
+            return du[3] = u[1] * u[2] - (8 / 3) * u[3]
+        end
+        u0 = [1.0; 0.0; 0.0]
+        tspan = (0.0, 100.0)
+        prob = ODEProblem(lorenz, u0, tspan)
+        sol = solve(prob, MATLABDiffEq.ode45())
+        @test length(sol.t) > 1
+        @test length(sol.u[1]) == 3
 
-algs = [
-    MATLABDiffEq.ode23
-    MATLABDiffEq.ode45
-    MATLABDiffEq.ode113
-    MATLABDiffEq.ode23s
-    MATLABDiffEq.ode23t
-    MATLABDiffEq.ode23tb
-    MATLABDiffEq.ode15s
-]
+        algs = [
+            MATLABDiffEq.ode23
+            MATLABDiffEq.ode45
+            MATLABDiffEq.ode113
+            MATLABDiffEq.ode23s
+            MATLABDiffEq.ode23t
+            MATLABDiffEq.ode23tb
+            MATLABDiffEq.ode15s
+        ]
 
-for alg in algs
-    sol = solve(prob, alg())
+        for alg in algs
+            sol = solve(prob, alg())
+            @test length(sol.t) > 1
+        end
+    end
+else
+    @info "No MATLAB installation detected (MATLAB.libmx_size == 0); " *
+        "skipping the MATLAB runtime solving tests. The type-validation and " *
+        "static-analysis tests above still run and must pass."
 end


### PR DESCRIPTION
## Root cause

On `master`, `test/runtests.jl` (lines 12-44) unconditionally ran the runtime ODE-solving tests:

```julia
sol = solve(prob, MATLABDiffEq.ode45())
```

`solve` reaches `__solve` at `src/MATLABDiffEq.jl:118`, which calls `put_variable(get_default_msession(), ...)`. `get_default_msession()` constructs a `MATLAB.MSession`, which does `ccall(eng_open[], ...)` (`MATLAB/engine.jl:48`).

When no MATLAB is installed (every CI runner here, since there is no MATLAB license), MATLAB.jl is built with **dummy deps** (`libmx_size == 0`, the documented CI/AutoMerge path in MATLAB.jl's `deps/build.jl`). With `libmx_size == 0`, MATLAB.jl's `__init__` deliberately **skips binding all the engine/mxarray function-pointer `Ref`s** (`if libmx_size > 0 ... end`). So `eng_open[]` is an unassigned `Ref{Ptr{Cvoid}}`, and dereferencing it throws:

```
ERROR: LoadError: UndefRefError: access to undefined reference
  [1] MATLAB.MSession(...)        @ MATLAB engine.jl:48
  [3] get_default_msession        @ MATLAB engine.jl:124
  [4] __solve                     @ MATLABDiffEq src/MATLABDiffEq.jl:118
  ...                             @ test/runtests.jl:20
ERROR: Package MATLABDiffEq errored during testing
```

This is **not** a MATLAB.jl API regression and **not** a ModelingToolkit v11 glue bug: the `modelingtoolkitize` + `build_function(::MATLABTarget())` code generation at lines 107-115 runs fine on ModelingToolkit v11.26.8 / Symbolics v7.26.0. The failure is solely that the suite tries to open a MATLAB engine that does not exist.

## Fix

Gate the runtime ODE-solving tests on a real MATLAB being present, using `MATLAB.libmx_size > 0` — the exact flag MATLAB.jl itself uses to decide whether to load its native libraries. When MATLAB is present the tests run for real (now with explicit `@test` assertions on the returned solution, which the old code lacked). When absent, they are skipped with an informative `@info` message. The MATLAB-free interface and JET/static-analysis tests always run.

No assertions were loosened, skipped, `@test_broken`-ed, or wrapped in error-swallowing `try`/`catch`. The runtime tests are gated on a genuine environment-capability flag, not silenced.

## What was verified

Reproduced and fixed locally with an **isolated depot** on Julia 1.10.11, with `CI=true` so MATLAB.jl builds the dummy deps exactly as on CI (no MATLAB on the machine).

- **Unmodified `master`** (reproduction): suite errors at `test/runtests.jl:20` with `UndefRefError` (matches the failing CI logs). Interface (40/40) and Static Analysis (38/38) testsets passed before the error.
- **With this fix**: suite passes.
  ```
  [ Info: No MATLAB installation detected (MATLAB.libmx_size == 0); skipping the MATLAB runtime solving tests...
  Test Summary:           | Pass  Total  Time
  Interface Compatibility |   40     40  0.1s
  Test Summary:         | Pass  Total  Time
  Static Analysis Tests |   38     38  0.8s
  Testing MATLABDiffEq tests passed
  ```

### What could NOT be verified

There is **no MATLAB on this machine**, so the `HAS_MATLAB == true` branch (the actual ODE solves and their new assertions) was **not executed**. That path is unchanged in behavior from the original tests aside from the added `@test`s; it still needs a run on a machine with a MATLAB license to confirm end-to-end. Marking this PR `UNVERIFIED-needs-MATLAB` for that reason.

Runic: ran the Runic.jl formatter on `test/runtests.jl` (already formatted, no changes).

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)