### PR TITLE
Re-enable Downgrade workflow (strict, natural failure)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   downgrade:
-    if: false
+    # Runs strict (allow_reresolve=false); expected RED until MATLAB runtime is available on CI runners.
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:


### PR DESCRIPTION
Re-enables the Downgrade workflow by removing the `if: false` guard.

The downgrade job now runs strict (allow_reresolve=false); it is intentionally RED (a natural failure, not disabled) pending MATLAB runtime not on CI runners. It will auto-green once that resolves.

No floors were lowered, `allow-reresolve` was not added, and julia stays "1.10".

Please ignore this PR until it has been reviewed by @ChrisRackauckas.