### PR TITLE
Use SciMLTesting v1.0.0 (run_tests harness)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,13 +16,14 @@ ModelingToolkit = "8, 9, 10, 11"
 ParameterizedFunctions = "5"
 PrecompileTools = "1"
 Reexport = "0.2, 1.0"
+SciMLTesting = "1"
 Test = "<0.0.1, 1"
 julia = "1.10"
 
 [extras]
 ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ParameterizedFunctions", "Pkg"]
+test = ["Test", "ParameterizedFunctions", "SciMLTesting"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,64 +1,56 @@
-using Pkg
 using Test
 using DiffEqBase, MATLABDiffEq, ParameterizedFunctions
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "Core")
+run_tests(;
+    default = "Core",
+    core = () -> begin
+        # Interface tests - these test type validation without needing MATLAB runtime
+        include("interface_tests.jl")
 
-# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
-# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
-# is ignored, so develop the package by path to test the PR branch code.
-function activate_qa_env()
-    Pkg.activate(joinpath(@__DIR__, "qa"))
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    return Pkg.instantiate()
-end
+        # Static type-stability tests - these also run without MATLAB
+        include("jet_tests.jl")
 
-if GROUP == "Core" || GROUP == "All"
-    # Interface tests - these test type validation without needing MATLAB runtime
-    include("interface_tests.jl")
+        # The following tests require MATLAB runtime to be available
+        # They test the actual ODE solving functionality
 
-    # Static type-stability tests - these also run without MATLAB
-    include("jet_tests.jl")
+        f = @ode_def_bare LotkaVolterra begin
+            dx = a * x - b * x * y
+            dy = -c * y + d * x * y
+        end a b c d
+        p = [1.5, 1, 3, 1]
+        tspan = (0.0, 10.0)
+        u0 = [1.0, 1.0]
+        prob = ODEProblem(f, u0, tspan, p)
+        sol = solve(prob, MATLABDiffEq.ode45())
 
-    # The following tests require MATLAB runtime to be available
-    # They test the actual ODE solving functionality
+        function lorenz(du, u, p, t)
+            du[1] = 10.0(u[2] - u[1])
+            du[2] = u[1] * (28.0 - u[3]) - u[2]
+            return du[3] = u[1] * u[2] - (8 / 3) * u[3]
+        end
+        u0 = [1.0; 0.0; 0.0]
+        tspan = (0.0, 100.0)
+        prob = ODEProblem(lorenz, u0, tspan)
+        sol = solve(prob, MATLABDiffEq.ode45())
 
-    f = @ode_def_bare LotkaVolterra begin
-        dx = a * x - b * x * y
-        dy = -c * y + d * x * y
-    end a b c d
-    p = [1.5, 1, 3, 1]
-    tspan = (0.0, 10.0)
-    u0 = [1.0, 1.0]
-    prob = ODEProblem(f, u0, tspan, p)
-    sol = solve(prob, MATLABDiffEq.ode45())
+        algs = [
+            MATLABDiffEq.ode23
+            MATLABDiffEq.ode45
+            MATLABDiffEq.ode113
+            MATLABDiffEq.ode23s
+            MATLABDiffEq.ode23t
+            MATLABDiffEq.ode23tb
+            MATLABDiffEq.ode15s
+        ]
 
-    function lorenz(du, u, p, t)
-        du[1] = 10.0(u[2] - u[1])
-        du[2] = u[1] * (28.0 - u[3]) - u[2]
-        return du[3] = u[1] * u[2] - (8 / 3) * u[3]
-    end
-    u0 = [1.0; 0.0; 0.0]
-    tspan = (0.0, 100.0)
-    prob = ODEProblem(lorenz, u0, tspan)
-    sol = solve(prob, MATLABDiffEq.ode45())
-
-    algs = [
-        MATLABDiffEq.ode23
-        MATLABDiffEq.ode45
-        MATLABDiffEq.ode113
-        MATLABDiffEq.ode23s
-        MATLABDiffEq.ode23t
-        MATLABDiffEq.ode23tb
-        MATLABDiffEq.ode15s
-    ]
-
-    for alg in algs
-        sol = solve(prob, alg())
-    end
-end
-
-if GROUP == "QA"
-    activate_qa_env()
-    include("qa/qa.jl")
-end
+        for alg in algs
+            sol = solve(prob, alg())
+        end
+    end,
+    groups = Dict(
+        "QA" => (; env = joinpath(@__DIR__, "qa"), body = () -> begin
+            include(joinpath(@__DIR__, "qa", "qa.jl"))
+        end),
+    ),
+)


### PR DESCRIPTION
Replaces the hand-written `GROUP`-dispatch in `test/runtests.jl` with a single `SciMLTesting.run_tests(...)` call (SciMLTesting v1.0.0).

## Shape
Single-package, `GROUP`-dispatched, QA in an isolated `test/qa` sub-env, **default `GROUP="Core"`**.

## Mapping (behavior-equivalent)
- `core` = thunk reproducing the original `Core||All` body verbatim: `include("interface_tests.jl")`, `include("jet_tests.jl")`, and the inline `@ode_def_bare`/`solve` MATLAB-runtime checks. A thunk (not a file include) is required because that body runs in the `runtests.jl` scope where `using DiffEqBase, MATLABDiffEq, ParameterizedFunctions` is in effect.
- `QA` = `groups["QA"]` with a declared `env = test/qa`. A declared-env group is **not** run under `"All"` and is selectable only via `GROUP="QA"`, exactly matching the original (`if GROUP == "QA"`). `activate_group_env` reproduces the old `activate_qa_env` (activate `test/qa` + `Pkg.develop` the repo root + instantiate). QA body kept verbatim (custom `JET.report_package` + report-count assertion), not collapsed into `run_qa`.
- `default = "Core"` preserves the original `get(ENV, "GROUP", "Core")`.

Routing verified for every CI-relevant `GROUP`: unset→core, All→core, Core→core, QA→qa.

## Project.toml
- `[extras]`/`[targets].test`/`[compat]`: add `SciMLTesting` (UUID `09d9d899-...`), drop `Pkg` (only the old harness used it; `Pkg.` appears in no other test file; SciMLTesting bundles Pkg).

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)