### PR TITLE
Bump version to 1.6.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MATLABDiffEq"
 uuid = "e2752cbe-bcf4-5895-8727-84ebc14a76bd"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
Automated patch version bump (1.6.0 -> 1.6.1) to release unreleased commits on `master` via JuliaRegistrator.