### PR TITLE
Use SciMLTesting 2.1 QA docs check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ PrecompileTools = "1.1"
 Reexport = "0.2, 1.0"
 SafeTestsets = "0.1, 1"
 SciMLBase = "3.27"
-SciMLTesting = "1"
+SciMLTesting = "2.1"
 Test = "<0.0.1, 1"
 julia = "1.10"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,5 @@
+# MATLABDiffEq.jl
+
+```@autodocs
+Modules = [MATLABDiffEq]
+```

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-MATLABDiffEq = {path = "/home/crackauc/sandbox/tmp_20260708_051717_3275/repos/MATLABDiffEq.jl"}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -7,12 +7,12 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
-MATLABDiffEq = {path = "../.."}
+MATLABDiffEq = {path = "/home/crackauc/sandbox/tmp_20260708_051717_3275/repos/MATLABDiffEq.jl"}
 
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.7"
+SciMLTesting = "2.1"
 Test = "<0.0.1, 1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,6 +3,7 @@ using SciMLTesting, MATLABDiffEq, JET, Test
 run_qa(
     MATLABDiffEq;
     explicit_imports = true,
+    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         # DiffEqBase.__solve (SciMLBase-owned) is the documented solver extension
         # point re-exported by DiffEqBase, and the Symbolics-owned MATLABTarget is


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Updates SciMLTesting compat entries to 2.1.
- Enables the shared SciMLTesting rendered public API docs QA check.
- Adds docs rendering needed by the shared check.

## Validation
- Runic check on changed Julia files.
- TOML parse check on edited Project files.
- Local QA group with GROUP=QA timeout 3600.