### PR TITLE
Release prep: bump MATLABDiffEq to 1.6.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MATLABDiffEq"
 uuid = "e2752cbe-bcf4-5895-8727-84ebc14a76bd"
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test-scaffolding changes since 1.6.1 (SciMLTesting test-compat bump, added docs autodocs page, QA config updates); no functional/runtime changes.